### PR TITLE
Implement the timestamp conversion logic to the ROS 2 ouster driver

### DIFF
--- a/ros2_ouster/CMakeLists.txt
+++ b/ros2_ouster/CMakeLists.txt
@@ -22,6 +22,8 @@ find_package(pcl_conversions REQUIRED)
 find_package(ouster_msgs REQUIRED)
 find_package(PCL REQUIRED COMPONENTS common)
 find_package(jsoncpp REQUIRED)
+find_package(rdv_msgs REQUIRED)
+find_package(rdv_vehicle_interface_base REQUIRED)
 
 include_directories(
   include

--- a/ros2_ouster/CMakeLists.txt
+++ b/ros2_ouster/CMakeLists.txt
@@ -50,6 +50,7 @@ set(dependencies
   ouster_msgs
   tf2_geometry_msgs
   pcl_conversions
+  rdv_vehicle_interface_base 
 )
 
 add_library(${library_name} SHARED

--- a/ros2_ouster/include/ros2_ouster/conversions.hpp
+++ b/ros2_ouster/include/ros2_ouster/conversions.hpp
@@ -30,6 +30,7 @@
 #include "sensor_msgs/msg/laser_scan.hpp"
 #include "tf2/LinearMath/Transform.h"
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+#include "rdv_vehicle_interface_base/timestamp_translator.h"
 
 #include "ouster_msgs/msg/metadata.hpp"
 
@@ -191,7 +192,8 @@ inline sensor_msgs::msg::PointCloud2 toMsg(
   const pcl::PointCloud<ouster_ros::Point> & cloud,
   const std::chrono::nanoseconds timestamp,
   const std::string & frame,
-  const uint64_t override_ts)
+  const uint64_t override_ts,
+  TimestampTranslator& timestamp_translator)
 {
   sensor_msgs::msg::PointCloud2 msg{};
   pcl::toROSMsg(cloud, msg);

--- a/ros2_ouster/include/ros2_ouster/conversions.hpp
+++ b/ros2_ouster/include/ros2_ouster/conversions.hpp
@@ -192,8 +192,7 @@ inline sensor_msgs::msg::PointCloud2 toMsg(
   const pcl::PointCloud<ouster_ros::Point> & cloud,
   const std::chrono::nanoseconds timestamp,
   const std::string & frame,
-  const uint64_t override_ts,
-  TimestampTranslator& timestamp_translator)
+  const uint64_t override_ts)
 {
   sensor_msgs::msg::PointCloud2 msg{};
   pcl::toROSMsg(cloud, msg);

--- a/ros2_ouster/include/ros2_ouster/full_rotation_accumulator.hpp
+++ b/ros2_ouster/include/ros2_ouster/full_rotation_accumulator.hpp
@@ -22,8 +22,10 @@
 
 #include "ros2_ouster/exception.hpp"
 #include "rdv_vehicle_interface_base/timestamp_translator.h"
-#include <rdv_msgs/PpsCounterReset.h>
-#include "std_srvs/Trigger.h"
+#include "rdv_msgs/srv/pps_counter_reset.hpp"
+#include "std_srvs/srv/trigger.hpp"
+
+using namespace std::chrono_literals;
 
 
 namespace sensor
@@ -38,8 +40,9 @@ class FullRotationAccumulator
 public:
   FullRotationAccumulator(
     const ouster::sensor::sensor_info & mdata,
-    const ouster::sensor::packet_format & pf)
-  : _batchReady(false), _pf(pf), _packets_accumulated(0)
+    const ouster::sensor::packet_format & pf,
+    rclcpp::Client<rdv_msgs::srv::PpsCounterReset>::SharedPtr pps_reset_client)
+  : _batchReady(false), _pf(pf), _packets_accumulated(0), _pps_reset_client(pps_reset_client)
   {
     _batch = std::make_unique<ouster::ScanBatcher>(mdata.format.columns_per_frame, _pf);
     _ls = std::make_shared<ouster::LidarScan>(
@@ -77,23 +80,20 @@ public:
     if (!_batchReady) {
       throw ros2_ouster::OusterDriverException("Full rotation not accumulated.");
     }
-    
-    TimestampTranslator timestamp_translator {
-      {std::chrono::seconds{2}, 1,
-      TimestampTranslator::Method::kPpsToSystemClock}};
-      rclcpp::Client<rdv_msgs::PpsCounterReset>::SharedPtr pps_reset_client =
-         node->create_client<rdv_msgs::PpsCounterReset>("/vehicle_interface/reset_pps_counter");
-
-         bool has_reset_pps_counter{false};
-    }
-
-     ros::ServiceClient pps_reset_client =
-        nh.serviceClient<rdv_msgs::PpsCounterReset>(
-            "/vehicle_interface/reset_pps_counter");
-    bool has_reset_pps_counter{false};
 
     return _timestamp;
   }
+
+  /**
+   * @brief Function for resetting the PPS second counter
+   */
+   bool trigger_reset_pps_second_counter(std_srvs::srv::Trigger::Request::SharedPtr req,
+                                         std_srvs::srv::Trigger::Response::SharedPtr res) 
+    {
+      _has_reset_pps_counter = false;
+      res->success = true;
+      return res->success;
+    }
 
   /**
    * @brief Takes packet data to batch it into a lidarscan
@@ -112,8 +112,25 @@ public:
         _ls->headers.begin(), _ls->headers.end(), [](const auto & h) {
           return h.timestamp != std::chrono::nanoseconds{0};
         });
+
+      auto pps_time{h->timestamp % 1s};
+      if (!_has_reset_pps_counter && 300ms < pps_time &&
+          pps_time < 500ms) {
+
+          auto request = std::make_shared<rdv_msgs::srv::PpsCounterReset::Request>();
+          auto result = _pps_reset_client->async_send_request(request);
+
+          if (result.wait_for(500ms) == std::future_status::ready) {
+              _timestamp_translator.resetPpsSecondCounter(
+                  std::chrono::nanoseconds{
+                      result.get()->time_of_reset});
+              _has_reset_pps_counter = true;
+                RCLCPP_INFO(rclcpp::get_logger("Ouster Lidar Driver"), "PPS second counter reset successful");
+          }
+      }
+
       if (h != _ls->headers.end()) {
-        _timestamp = h->timestamp;
+        _timestamp = pps_time;
       }
       _batchReady = true;
     }
@@ -130,6 +147,13 @@ private:
   std::unique_ptr<ouster::ScanBatcher> _batch;
   std::shared_ptr<ouster::LidarScan> _ls;
   ouster::sensor::packet_format _pf;
+
+  bool _has_reset_pps_counter;
+  TimestampTranslator _timestamp_translator {
+    {std::chrono::seconds{2}, 1,
+    TimestampTranslator::Method::kPpsToSystemClock}
+  };
+  rclcpp::Client<rdv_msgs::srv::PpsCounterReset>::SharedPtr _pps_reset_client;
 
   uint64_t _packets_accumulated = 0;
 };

--- a/ros2_ouster/include/ros2_ouster/full_rotation_accumulator.hpp
+++ b/ros2_ouster/include/ros2_ouster/full_rotation_accumulator.hpp
@@ -21,6 +21,10 @@
 #include <vector>
 
 #include "ros2_ouster/exception.hpp"
+#include "rdv_vehicle_interface_base/timestamp_translator.h"
+#include <rdv_msgs/PpsCounterReset.h>
+#include "std_srvs/Trigger.h"
+
 
 namespace sensor
 {
@@ -73,6 +77,20 @@ public:
     if (!_batchReady) {
       throw ros2_ouster::OusterDriverException("Full rotation not accumulated.");
     }
+    
+    TimestampTranslator timestamp_translator {
+      {std::chrono::seconds{2}, 1,
+      TimestampTranslator::Method::kPpsToSystemClock}};
+      rclcpp::Client<rdv_msgs::PpsCounterReset>::SharedPtr pps_reset_client =
+         node->create_client<rdv_msgs::PpsCounterReset>("/vehicle_interface/reset_pps_counter");
+
+         bool has_reset_pps_counter{false};
+    }
+
+     ros::ServiceClient pps_reset_client =
+        nh.serviceClient<rdv_msgs::PpsCounterReset>(
+            "/vehicle_interface/reset_pps_counter");
+    bool has_reset_pps_counter{false};
 
     return _timestamp;
   }

--- a/ros2_ouster/include/ros2_ouster/ouster_driver.hpp
+++ b/ros2_ouster/include/ros2_ouster/ouster_driver.hpp
@@ -144,6 +144,7 @@ private:
 
   rclcpp::Service<std_srvs::srv::Empty>::SharedPtr _reset_srv;
   rclcpp::Service<ouster_msgs::srv::GetMetadata>::SharedPtr _metadata_srv;
+  rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr _pps_second_reset_srv;
 
   std::unique_ptr<SensorInterface> _sensor;
   std::multimap<ouster::sensor::client_state,

--- a/ros2_ouster/package.xml
+++ b/ros2_ouster/package.xml
@@ -26,6 +26,8 @@
   <depend>pcl_conversions</depend>
   <depend>libpcl-all</depend>
   <depend>libtins-dev</depend>
+  <depend>rdv_vehicle_interface_base</depend>
+  <depend>rdv_msgs</depend>
 
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/ros2_ouster/src/ouster_driver.cpp
+++ b/ros2_ouster/src/ouster_driver.cpp
@@ -117,8 +117,15 @@ void OusterDriver::onConfigure()
   _metadata_srv = this->create_service<ouster_msgs::srv::GetMetadata>(
     "~/get_metadata", std::bind(&OusterDriver::getMetadata, this, _1, _2, _3));
 
+  rclcpp::Client<rdv_msgs::srv::PpsCounterReset>::SharedPtr pps_second_counter_reset_client_ =
+    this->create_client<rdv_msgs::srv::PpsCounterReset>("/vehicle_interface/reset_pps_counter");
+
   _full_rotation_accumulator = std::make_shared<sensor::FullRotationAccumulator>(
-    _sensor->getMetadata(), _sensor->getPacketFormat());
+    _sensor->getMetadata(), _sensor->getPacketFormat(), pps_second_counter_reset_client_);
+
+   
+   _pps_second_reset_srv = this->create_service<std_srvs::srv::Trigger>(
+    "/lidar_driver/pps_reset_client_trigger", std::bind(&sensor::FullRotationAccumulator::trigger_reset_pps_second_counter, _full_rotation_accumulator, _1, _2));
 
   if (_use_system_default_qos) {
     RCLCPP_INFO(


### PR DESCRIPTION
Implemented the timestamp conversion logic from timestamp_translator to the ouster driver to convert PPS timestamps into UNIX timestamps. This is to enable SLAM to browse and compare the timestamps from the LiDAR and VN-300 to match them. The most important thing is that they are accurate in relation to each other, for example, a 0.1 second difference in the converted UNIX timestamps corresponds to a 0.1 second difference in the original PPS timestamps.

This has currently only been tested with 
`colcon build --packages-select ouster_lidar_driver`

https://github.com/RevolveNTNU/autonomous_pipeline/issues/1389

